### PR TITLE
Added JSON API and web frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,42 +5,20 @@ This is done by directly establishing sessions with a number of peers using
 [GoBGP](https://github.com/osrg/gobgp) and abstracting away the more complex
 methods.
 
+
 ## Getting Started
 
 1. Check out the provided `example_config.yml` and write your own version
-2. Configure you routers to talk to you, on Cisco IOS-XR, it should look right about this:
+2. Configure BGP sessions to your looking glass server. In most cases it
+   makes sense to run the routeinfo-server as iBGP route-reflector client.
+3. Run the API server or use RouteInfo as module in your own software.
 
-```
-conf
-router bgp 553
- neighbor x.x.x.x
-  remote-as 553
-  description BGP RouteInfo
-  update-source Loopback0
-  address-family ipv4 unicast
-   route-policy bgp-routeinfo-in in
-   route-reflector-client
-   route-policy bgp-routeinfo-out out
-   soft-reconfiguration inbound always
-  !
- !
-!
- neighbor xy::z
-  remote-as 553
-  description BGP RouteInfo
-  update-source Loopback0
-  address-family ipv6 unicast
-   route-policy bgp-routeinfo-in in
-   route-reflector-client
-   route-policy bgp-routeinfo-out out
-   soft-reconfiguration inbound always
-  !
- !
-!
-commit
-end
-```
+You can run `cmd/routeinfo_server/main.go` to start a JSON/HTTP API server
+and use the files in `lookingglass` to set up a web-frontend that can
+query that API server. It is neccessary to edit `config.js`, but
+`lookingglass.html` and `style.css` should also be seen as examples and can
+be adapted or integrated into an existing website.
 
-Then use the API in your application. There's an example in `cmd/example`, but
-it mainly consists of doing a YAML Unmarshal into an empty RouteInfoServer
-object and using its `Lookup` methods.
+You can also use this in your own application. There's an example in
+`cmd/example`, but it mainly consists of doing a YAML Unmarshal into an empty
+RouteInfoServer object and using its `Lookup` methods.

--- a/cmd/routeinfo_server/main.go
+++ b/cmd/routeinfo_server/main.go
@@ -63,6 +63,7 @@ func main() {
 	go func() {
 		<-sigc
 		rs.Stop()
+		os.Exit(0)
 	}()
 
 	http.HandleFunc("/prefix", prefix)

--- a/cmd/routeinfo_server/main.go
+++ b/cmd/routeinfo_server/main.go
@@ -18,9 +18,9 @@ type PrefixResult struct {
 }
 
 type RouterStatus struct {
-	Router string `json:"router"`
+	Router    string `json:"router"`
 	Connected bool   `json:"connected"`
-	Ready  bool   `json:"ready"`
+	Ready     bool   `json:"ready"`
 }
 
 type StatusResponse struct {
@@ -62,7 +62,7 @@ func status(writer http.ResponseWriter, request *http.Request) {
 	for name, router := range rs.Routers {
 		var rStatus RouterStatus
 		rStatus.Router = name
-        rStatus.Connected, rStatus.Ready = router.Status()
+		rStatus.Connected, rStatus.Ready = router.Status()
 		response.Results = append(response.Results, rStatus)
 	}
 	body, err := json.Marshal(response)
@@ -74,6 +74,7 @@ func status(writer http.ResponseWriter, request *http.Request) {
 	writer.Header().Set("Content-Type", "application/json")
 	writer.Header().Set("Access-Control-Allow-Origin", "*")
 	writer.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+
 	writer.Write(body)
 }
 
@@ -117,8 +118,10 @@ func prefix(writer http.ResponseWriter, request *http.Request) {
 		// can't really add error strings to the body here anymore...
 		http.Error(writer, err.Error(), http.StatusInternalServerError)
 	}
+
 	writer.Header().Set("Content-Type", "application/json")
 	writer.Header().Set("Access-Control-Allow-Origin", "*")
 	writer.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+
 	writer.Write(body)
 }

--- a/lookingglass/config.js
+++ b/lookingglass/config.js
@@ -1,0 +1,56 @@
+lgSettings = {
+    "routeinfoAPI": {
+        "URL": "https://example.org:3000",  // URL of your API server (without trailing slash)
+        "showAPILink": true,  // show "link to raw JSON result"
+    },
+    "graph": {
+        "enabled": true,  // render a BGP tree (requires mermaid.js)
+        "localASName": "My Network"  // display name of your AS
+    },
+    "tags": {
+        // additional data for tags
+        // "description" is displayed as tooltip
+        // "class" is added as CSS class "lg-tag-class-$class" (i.e. "class": "best" will turn into ".lg-tag-class-best")
+        // (can be used for styling, e.g. to turn blackhole-communities red)
+        "best": {
+            "description": "router-local best-path",
+            "class": "best"
+        },
+        "RPKI NotFound": {
+            "description": "RPKI origin validation status \"NotFound\"",
+            "class": "rpki-notfound"
+        },
+        "RPKI Valid": {
+            "description": "RPKI origin validation status \"Valid\"",
+            "class": "rpki-valid"
+        },
+        "RPKI Invalid": {
+            "description": "RPKI origin validation status \"Invalid\"",
+            "class": "rpki-invalid"
+        },
+        "65535:0": {
+            "description": "GRACEFUL_SHUTDOWN",
+            "class": "action-restrict"
+        },
+        "65535:666": {
+            "description": "BLACKHOLE",
+            "class": "action-blackhole"
+        },
+        "65535:65281": {
+            "description": "NO_EXPORT",
+            "class": "action-restrict"
+        },
+        "65535:65282": {
+            "description": "NO_ADVERTISE",
+            "class": "action-restrict"
+        },
+        "65535:65283": {
+            "description": "NO_EXPORT_SUBCONFED",
+            "class": "action-restrict"
+        },
+        "65535:65284": {
+            "description": "NOPEER",
+            "class": "action-restrict"
+        }
+    }
+}

--- a/lookingglass/lookingglass.html
+++ b/lookingglass/lookingglass.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>BelWü :: Route-Server</title>
+    <meta charset="utf-8">
+    <meta name="title" content="Looking Glass">
+    <script src="config.js" defer></script>
+    <script src="lookingglass.js" defer></script>
+    <link rel="stylesheet" href="style.css">
+  </head>
+  <body>
+    <div id="lg-container">
+    </div>
+    <template id="lg-template-query">
+      <div id="lg-query-block" class="lg-query-block">
+        <div id="lg-query-form-block" class="lg-query-form-block">
+          <h1 id="lg-query-heading"></h1>
+          <form id="lg-query-form" action="" method="dialog" onSubmit="javascipt:queryPrefix();">
+            <input id="lg-query-prefix" type="text" placeholder="Address/Prefix (e.g.2001:db0::/32)" pattern="^(([0-9]+\.){3}[0-9]+|[0-9a-fA-F:]+)(\/[0-9]+)?$" required>
+            <select id="lg-query-router" required>
+              <option value="-" hidden disabled selected></option>
+              <option value="">(all)</option>
+            </select>
+            <input type="submit" value="Go">
+          </form>
+        </div>
+      </div>
+    </template>
+    <template id="lg-template-result-prefix">
+      <div id="lg-result-block">
+        <p id="lg-prefix-results" class="lg-prefix-results"></p>
+      </div>
+    </template>
+    <template id="lg-template-prefix-router">
+      <div id="lg-prefix-router" class="lg-prefix-router">
+        <h2 id="lg-prefix-result-info" class="lg-prefix-result-info">Router <span id="lg-prefix-router-name" class="lg-prefix-router-name"></span><br><span id="lg-prefix-router-prefix" class="lg-prefix-router-prefix"></span></h2>
+      </div>
+    </template>
+    <template id="lg-template-path">
+      <p id="lg-path" class="lg-path">
+        <span id="lg-path-aspath" class="lg-path-aspath"></span><br><span id="lg-path-nexthop" class="lg-path-nexthop"></span><br><span id="lg-path-metrics" class="lg-path-metrics"></span><br><span id="lg-path-tags" class="lg-path-tags"></span>
+      </p>
+    </template>
+    <template id="lg-template-tag">
+      <span id="lg-tag" class="lg-tag"></span>
+    </template>
+    <template id="lg-template-api-link">
+      <div id="lg-api-link-box" class="lg-api-link-box">
+        <a id="lg-api-link" class="lg-api-link" alt="JSON API Link" target="_blank">Result as raw JSON &#128279;</a>
+      </div>
+    </template>
+  </body>
+</html>

--- a/lookingglass/lookingglass.js
+++ b/lookingglass/lookingglass.js
@@ -1,0 +1,287 @@
+// TODO
+// BropathEwsersupport-Check
+// if ('content' in document.createElement('template')) {
+
+var statusURL = lgSettings.routeinfoAPI.URL + "/status";
+var prefixURL = lgSettings.routeinfoAPI.URL + "/prefix";
+
+// RFC 6811 
+var validityMapping = {
+    0: "Valid",
+    1: "NotFound",
+    2: "Invalid"
+}
+
+// RFC 4271
+var originMapping = {
+    0: "IGP",
+    1: "EGP",
+    2: "Incomplete"
+}
+
+function pathCompare(a, b) {
+    // best path wins for readability
+    if (!a.best && b.best) return -1;
+    if (a.best && !b.best) return 1;
+
+    // localpref (higher is better)
+    if (a.localpref < b.localpref) return -1;
+    if (a.localpref > b.localpref) return 1;
+
+    // as-path length (shorter is better)
+    if (a.aspath.length > b.aspath.length) return -1;
+    if (a.aspath.length < b.aspath.length) return 1;
+
+    // origin IGP > EGP > Incomplete
+    if (a.origin > b.origin) return -1;
+    if (a.origin < b.origin) return 1;
+
+    // MED (lower is better)
+    if (a.med > b.med) return -1;
+    if (a.med < b.med) return 1;
+
+    // TODO find a way to check if the neighbor larned the path via iBGP
+    // eBGP wins over iBGP
+
+    // more esoteric comparisons could happen here
+    // ignored for looking-glass purposes
+    return 0;
+}
+
+function addTextElement(tag, text, container, classes = []) {
+    var element = document.createElement(tag);
+    classes.forEach(function(classname){
+        element.classList.add(classname);
+    });
+    var text = document.createTextNode(text);
+    element.appendChild(text);
+    container.appendChild(element);
+}
+
+function newTag(text) {
+    var tagTemplate = document.querySelector("#lg-template-tag");
+    var tag = document.importNode(tagTemplate.content, true);
+    var tagElement = tag.querySelector("#lg-tag");
+    tagElement.textContent = text;
+    var tagInfo = lgSettings.tags[text];
+    if (tagInfo) {
+        tagElement.classList.add(`lg-tag-class-${tagInfo.class}`);
+        tagElement.classList.add("lg-tag-tooltip");
+        var tooltipText = document.createElement("span");
+        tooltipText.textContent = tagInfo.description;
+        tooltipText.classList.add("lg-tooltiptext")
+        tagElement.appendChild(tooltipText);
+    }
+    return tag;
+}
+
+function addPathElement(path, container) {
+    // path block
+    var pathElementTemplate = document.querySelector("#lg-template-path");
+    var pathElement = document.importNode(pathElementTemplate.content, true);
+
+    // path data (as-path, next-hop, timestamp, metrics)
+    if ("aspath" in path && path.aspath) {
+        pathElement.querySelector("#lg-path-aspath").textContent = path.aspath.join(" ");
+    } else {
+        pathElement.querySelector("#lg-path-aspath").textContent = "(local)";
+    }
+    pathElement.querySelector("#lg-path-nexthop").textContent = `via ${path.nexthop} (since ${path.timestamp})`;
+    pathElement.querySelector("#lg-path-metrics").textContent = `Localpref: ${path.localpref}, MED: ${path.med}, Origin: ${originMapping[path.origin]}`;
+
+    // tags (bestpath, ROV-status)
+    var tagSection = pathElement.querySelector("#lg-path-tags");
+    if (path.best === true) {
+        pathElement.querySelector("#lg-path").classList.add("lg-path-best");
+        tagSection.appendChild(newTag("best"));
+    }
+        tagSection.appendChild(newTag(`RPKI ${validityMapping[path.validation]}`));
+
+    // communities and large-communities
+    var tagSection = pathElement.querySelector("#lg-path-tags");
+    if (path.communities) {
+        path.communities.forEach(function(community){
+            tagSection.appendChild(newTag(community));
+        });
+    }
+    if (path.largecommunities) {
+        path.largecommunities.forEach(function(community){
+            tagSection.appendChild(newTag(community));
+        });
+    }
+
+    // append the path to the container
+    container.appendChild(pathElement);
+}
+
+function newWarningMessage(text) {
+        var oopsie = document.createElement("p");
+        oopsie.textContent = text;
+        oopsie.classList.add("lg-warning");
+        return oopsie;
+}
+
+function displayStatus(data, container) {
+    // TODO check errors
+    if (!("results" in data) || (data.results == null) || (data.results.length == 0)) {
+        container.appendChild(newWarningMessage("The route-server is not available at the moment. Please try again later."));
+        return;
+    }
+    var routers = data.results;
+    var routerCount = 0;
+    routers.forEach(function(router){
+        if (router.ready) {
+            routerCount++;
+        }
+    });
+    if (routerCount == 0) {
+        container.appendChild(newWarningMessage("No routers are available for lookups at the moment. Please try again later."));
+        return;
+    }
+
+    var querySection = document.querySelector("#lg-template-query");
+    var clone = document.importNode(querySection.content, true);
+    clone.querySelector("#lg-query-heading").textContent = "Routing Info is Available for " + routerCount + " Routers";
+    var select = clone.querySelector("#lg-query-router");
+    routers.forEach(function(router){
+        let option = document.createElement("option");
+        option.value = router.router;
+        option.textContent = router.router;
+        if (!router.ready) {
+            option.disabled = true;
+        }
+        select.appendChild(option);
+    });
+
+    container.appendChild(clone);
+
+    // load query data from URL and (if a query is already there) run it
+    loadQuery();
+}
+
+function addPrefixResult(result, container) {
+    // TODO check errors
+    var prefixRouterTemplate = document.querySelector("#lg-template-prefix-router");
+    var clone = document.importNode(prefixRouterTemplate.content, true);
+    var prefixRouterSection = clone.querySelector("#lg-prefix-router");
+    clone.querySelector("#lg-prefix-router-name").textContent = result.router;
+    clone.querySelector("#lg-prefix-router-prefix").textContent = result.prefix;
+    result.paths.sort(pathCompare);
+    result.paths.reverse();
+    result.paths.forEach(function(path){
+        addPathElement(path, prefixRouterSection);
+    });
+    container.appendChild(clone);
+}
+
+function displayPrefix(data, container) {
+    // activate loading queries on hash change (gets disabled before on new queries)
+    window.onhashchange = loadQuery;
+
+    // get a new result block
+    var resultPrefixSection = document.querySelector("#lg-template-result-prefix");
+    var clone = document.importNode(resultPrefixSection.content, true);
+    var resultBlock = clone.querySelector("#lg-result-block");
+
+    if (!("results" in data) || (data.results == null) || (data.results.length == 0)) {
+        resultBlock.appendChild(newWarningMessage("No prefixes found."));
+        container.appendChild(clone);
+        return;
+    }
+
+    // fill the block with data
+    var prefixResults = resultBlock.querySelector("#lg-prefix-results");
+    data.results.forEach(function(result){
+        addPrefixResult(result, prefixResults);
+    });
+
+    // append the block to the container
+    container.appendChild(clone);
+}
+
+function queryStatus() {
+    var container = document.querySelector("#lg-container");
+    fetch(statusURL, {
+        "method": "GET",
+        "cache": "no-store"
+    })
+        .then(response => response.json())
+        .then(response => displayStatus(response, container))
+    // TODO handle .catch
+}
+
+function queryPrefix() {
+    // disable request on hash change (will be enabled in displayPrefix when the response has arrived)
+    window.onhashchange = function(){ return; }
+
+    // clear the last result
+    var lastResultSection = document.querySelector("#lg-result-block");
+    if (lastResultSection) { lastResultSection.remove(); }
+
+    var container = document.querySelector("#lg-container");
+
+    var prefix = document.querySelector("#lg-query-prefix").value;
+    var routerSelect = document.querySelector("#lg-query-router");
+    var router = routerSelect.options[routerSelect.selectedIndex].value;
+
+    // store query data in the URL hash part
+    var formData = new FormData();
+    formData.append("prefix", prefix);
+    formData.append("router", router);
+    var hash = new URLSearchParams(formData).toString();
+
+    window.location.hash = hash;
+
+    // hack: URL() doesn't work with relative URLs...
+    var url = new URL((new Request(prefixURL)).url);
+    url.searchParams.append("prefix", prefix);
+    url.searchParams.append("router", router);
+
+    // TODO loading screen
+
+    fetch(url, {
+        "method": "GET",
+        "cache": "no-store"
+    })
+        .then(response => response.json())
+        .then(response => displayPrefix(response, container))
+    // TODO handle .catch
+
+    // display a link to raw JSON output
+    if (lgSettings.routeinfoAPI.showAPILink) {
+        var apiLinkTemplate = document.querySelector("#lg-template-api-link");
+        var apiLink = document.importNode(apiLinkTemplate.content, true);
+        apiLink.querySelector("#lg-api-link").href = url;
+        var querySection = document.querySelector("#lg-query-block");
+        querySection.appendChild(apiLink);
+    }
+}
+
+function loadQuery() {
+    // disable request on hash change (will be enabled in displayPrefix when the response has arrived)
+    window.onhashchange = function(){ return; }
+
+    // load the query from the anchor-part of the URL, if there is one
+    var hash = window.location.hash.substring(1);
+    if (!hash) { return; }
+    var queryData = new URLSearchParams(hash);
+    var prefix = queryData.get("prefix");
+    var router = queryData.get("router");
+
+    var prefixInputElement = document.querySelector("#lg-query-prefix");
+    prefixInputElement.value = prefix;
+    var routerSelectElement = document.querySelector("#lg-query-router");
+    routerSelectElement.value = router;
+    if (routerSelectElement.selectedIndex == -1) {
+        routerSelectElement.value = "";
+    }
+
+    //queryPrefix();
+    var form = document.querySelector("#lg-query-form");
+    if (form.reportValidity()) {
+        queryPrefix();
+    }
+    window.onhashchange = loadQuery;
+}
+
+queryStatus();

--- a/lookingglass/style.css
+++ b/lookingglass/style.css
@@ -1,0 +1,103 @@
+.lg-warning {
+    font-size: 1.3rem;
+    color: #311;
+    background-color: #ffc;
+    padding: 0.4em;
+    border: 1px dashed #311;
+    border-radius: 8px;
+}
+
+.lg-api-link:link, .lg-api-link:visited, .lg-api-link:active {
+    font-size: 0.8rem;
+    text-decoration: none;
+    color: #888;
+    background-color: #f3f3f3;
+    border-radius: 0.2rem;
+    margin-top: 0.3rem;
+    margin-bottom: 0.3rem;
+}
+.lg-api-link:hover {
+    color: #666;
+    background-color: white;
+}
+
+.lg-prefix {
+    font-family: monospace;
+}
+.lg-prefix-router {
+    background: #f3f3f3;
+    padding: 0.7rem;
+    border-radius: 8px;
+    margin-bottom: 2rem;
+}
+.lg-path {
+    font-family: monospace;
+    padding-left: 1rem;
+    border-left: 2px solid #ccc;
+    padding-bottom: 0.3rem;
+}
+.lg-path-best {
+    border-left: 2px solid darkgreen;
+}
+.lg-prefix-router-prefix {
+    font-family: monospace;
+}
+.lg-path-aspath {
+    font-size: 1.25rem;
+    font-weight: bold;
+}
+
+.lg-tag {
+    color: white;
+    margin-right: 0.2rem;
+    border-radius: 0.2rem;
+    padding-left: 0.2rem;
+    padding-right: 0.2rem;
+}
+.lg-tag-tooltip {
+    position: relative;
+    display: inline-block;
+    border-bottom: 1px dotted black;
+}
+.lg-tag-tooltip .lg-tooltiptext {
+    visibility: hidden;
+    width: 10rem;
+    background-color: #111;
+    color: #fff;
+    text-align: center;
+    padding: 5px 0;
+    border-radius: 6px;
+    position: absolute;
+    z-index: 1;
+    bottom: 125%;
+    left: 50%;
+    margin-left: -5rem;
+    opacity: 0;
+    transition: opacity 0.3s;
+}
+.lg-tag-tooltip .lg-tooltiptext::after {
+    content: "";
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    margin-left: -5px;
+    border-width: 5px;
+    border-style: solid;
+    border-color: #111 transparent transparent transparent;
+}
+.lg-tag-tooltip:hover .lg-tooltiptext {
+    visibility: visible;
+    opacity: 1;
+}
+.lg-tag { background: lightgray; color: black; }
+.lg-tag-class-best { background: darkgreen; color: white; }
+.lg-tag-class-rpki-notfound { background: lightgray; color: black; }
+.lg-tag-class-rpki-valid { background: lightgreen; color: darkgreen; }
+.lg-tag-class-rpki-invalid { background: red; }
+.lg-tag-class-info-infra { background: yellow; color: brown; }
+.lg-tag-class-info-customer { background: lightgreen; color: darkgreen; }
+.lg-tag-class-info-peering { background: lightgreen; color: darkgreen; }
+.lg-tag-class-info-transit { background: yellow; color: brown; }
+.lg-tag-class-action-blackhole { background: red; color: white; }
+.lg-tag-class-action-restrict { background: black; color: lightgray; }
+.lg-tag-class-action-transit { background: lightblue; color: blue; }

--- a/routeinfo/routeinfo.go
+++ b/routeinfo/routeinfo.go
@@ -74,6 +74,12 @@ func (rs *RouteInfoServer) Init() {
 	}
 }
 
+func (rs *RouteInfoServer) Stop() {
+	for _, router := range rs.Routers {
+		router.GobgpServer.Stop()
+	}
+}
+
 type Router struct {
 	Name                     string   `yaml:"name"`
 	Asn                      uint32   `yaml:"asn"`

--- a/routeinfo/routeinfo.go
+++ b/routeinfo/routeinfo.go
@@ -153,7 +153,7 @@ func (r *Router) lookup(address string, lookupType api.TableLookupPrefix_Type) [
 
 	// no answer here
 	if destination == nil {
-		log.Printf("[warning] No destination returned for %s.\n", address)
+        //log.Printf("[warning] No destination returned for %s.\n", address)
 		return nil
 	}
 
@@ -202,8 +202,8 @@ func (r *Router) lookup(address string, lookupType api.TableLookupPrefix_Type) [
 				continue
 			} else if err := pattr.UnmarshalTo(OriginatorId); err == nil { //not used
 				continue
-			} else {
-				log.Printf("[warning] Path attribute decode not implemented for this object: %+v\n", pattr)
+			//} else {
+			//	log.Printf("[warning] Path attribute decode not implemented for this object: %+v\n", pattr)
 			}
 		}
 

--- a/routeinfo/routeinfo.go
+++ b/routeinfo/routeinfo.go
@@ -78,10 +78,10 @@ func (rs *RouteInfoServer) Stop() {
 	var wg sync.WaitGroup
 	for _, router := range rs.Routers {
 		wg.Add(1)
-		go func() {
+		go func(myrouter *Router) {
 			defer wg.Done()
-			router.GobgpServer.Stop()
-		}()
+			myrouter.GobgpServer.Stop()
+		}(router)
 	}
 	wg.Wait()
 }

--- a/routeinfo/routeinfo.go
+++ b/routeinfo/routeinfo.go
@@ -364,13 +364,12 @@ func (router *Router) Status() (bool, bool) {
 
 func (router *Router) Established() bool {
 	router.neighborSessionStateLock.Lock()
+	defer router.neighborSessionStateLock.Unlock()
 	for _, state := range router.neighborSessionState {
 		if state != api.PeerState_ESTABLISHED {
-			router.neighborSessionStateLock.Unlock()
 			return false
 		}
 	}
-	router.neighborSessionStateLock.Unlock()
 	return true
 }
 

--- a/routeinfo/routeinfo.go
+++ b/routeinfo/routeinfo.go
@@ -67,6 +67,9 @@ func (rs *RouteInfoServer) Init() {
 		if router.GobgpServer == nil {
 			router.GobgpServer = rs.getBgpInstance(router)
 		}
+		if router.neighborSessionState == nil {
+			router.neighborSessionState = make(map[string]api.PeerState_SessionState)
+		}
 		router.Connect()
 	}
 }

--- a/routeinfo/routeinfo.go
+++ b/routeinfo/routeinfo.go
@@ -72,8 +72,6 @@ type Router struct {
 	Asn         uint32   `yaml:"asn"`
 	Neighbors   []string `yaml:"neighbors"`
 	GobgpServer *server.BgpServer
-
-	peers []*api.Peer
 }
 
 func (r *Router) Connect() {
@@ -95,7 +93,6 @@ func (r *Router) Connect() {
 		}
 
 	}
-	r.getPeers()
 }
 
 func (r *Router) LookupShorter(address string) []RouteInfo {
@@ -156,7 +153,7 @@ func (r *Router) lookup(address string, lookupType api.TableLookupPrefix_Type) [
 
 	// no answer here
 	if destination == nil {
-		//log.Printf("[warning] No destination returned for %s.\n", address)
+        //log.Printf("[warning] No destination returned for %s.\n", address)
 		return nil
 	}
 
@@ -205,8 +202,8 @@ func (r *Router) lookup(address string, lookupType api.TableLookupPrefix_Type) [
 				continue
 			} else if err := pattr.UnmarshalTo(OriginatorId); err == nil { //not used
 				continue
-				//} else {
-				//	log.Printf("[warning] Path attribute decode not implemented for this object: %+v\n", pattr)
+			//} else {
+			//	log.Printf("[warning] Path attribute decode not implemented for this object: %+v\n", pattr)
 			}
 		}
 
@@ -348,23 +345,16 @@ type RouteInfo struct {
 func (r *Router) Status() (bool, bool) {
 	var connected = true
 	var ready = true
-	for _, peer := range r.peers {
-		connected = connected && peer.State.SessionState == api.PeerState_ESTABLISHED
-		for _, a := range peer.AfiSafis {
-			s := a.MpGracefulRestart.State
-			ready = ready && s.EndOfRibReceived
-		}
-	}
-	return connected, ready
-}
-
-func (r *Router) getPeers() {
-	r.peers = []*api.Peer{}
 	for _, addr := range r.Neighbors {
 		r.GobgpServer.ListPeer(context.Background(), &api.ListPeerRequest{Address: addr}, func(p *api.Peer) {
-			r.peers = append(r.peers, p)
+			connected = connected && p.State.SessionState == api.PeerState_ESTABLISHED
+			for _, a := range p.AfiSafis {
+				s := a.MpGracefulRestart.State
+				ready = ready && s.EndOfRibReceived
+			}
 		})
 	}
+	return connected, ready
 }
 
 func (r *Router) WaitForEOR() {

--- a/routeinfo/routeinfo.go
+++ b/routeinfo/routeinfo.go
@@ -194,7 +194,7 @@ func (r *Router) lookup(address string, lookupType api.TableLookupPrefix_Type) [
 		var OriginatorId = &api.OriginatorIdAttribute{}
 
 		for _, pattr := range path.Pattrs {
-			if err := pattr.UnmarshalTo(Origin); err == nil { // TODO: this is useless and won't be read
+			if err := pattr.UnmarshalTo(Origin); err == nil {
 				continue
 			} else if err := pattr.UnmarshalTo(AsPath); err == nil {
 				continue
@@ -220,8 +220,8 @@ func (r *Router) lookup(address string, lookupType api.TableLookupPrefix_Type) [
 				continue
 			} else if err := pattr.UnmarshalTo(OriginatorId); err == nil { //not used
 				continue
-				//} else {
-				//	log.Printf("[warning] Path attribute decode not implemented for this object: %+v\n", pattr)
+			} else {
+				log.Printf("[warning] Path attribute decode not implemented for this object: %+v\n", pattr)
 			}
 		}
 

--- a/routeinfo/routeinfo.go
+++ b/routeinfo/routeinfo.go
@@ -232,7 +232,7 @@ func (r *Router) lookup(address string, lookupType api.TableLookupPrefix_Type) [
 		var communities []string
 		for _, community := range Communities.Communities {
 			front := community >> 16
-			back := community & 0xff
+			back := community & 0xffff
 			communities = append(communities, fmt.Sprintf("%d:%d", front, back))
 		}
 

--- a/routeinfo/routeinfo.go
+++ b/routeinfo/routeinfo.go
@@ -257,6 +257,13 @@ func (r *Router) lookup(address string, lookupType api.TableLookupPrefix_Type) [
 			origin = OriginValue(Origin.Origin)
 		}
 
+		var originAS uint32
+		if len(aspath) > 0 {
+			originAS = aspath[len(aspath)-1]
+		} else {
+			originAS = 0
+		}
+
 		result = RouteInfo{
 			AsPath:           aspath,
 			Best:             path.Best,
@@ -265,7 +272,7 @@ func (r *Router) lookup(address string, lookupType api.TableLookupPrefix_Type) [
 			LocalPref:        LocalPref.LocalPref,
 			Med:              MultiExitDisc.Med,
 			NextHop:          nexthop,
-			OriginAs:         aspath[len(aspath)-1],
+			OriginAs:         originAS,
 			Origin:           origin,
 			Peer:             path.NeighborIp,
 			Prefix:           fmt.Sprintf("%s/%d", Prefix.Prefix, Prefix.PrefixLen),

--- a/routeinfo/routeinfo.go
+++ b/routeinfo/routeinfo.go
@@ -133,9 +133,6 @@ func (r *Router) LookupLonger(address string) []RouteInfo {
 }
 
 func (r *Router) Lookup(address string) []RouteInfo {
-	if parsed, _, _ := net.ParseCIDR(address); parsed != nil {
-		address = parsed.String()
-	}
 	return r.lookup(address, api.TableLookupPrefix_EXACT)
 }
 

--- a/routeinfo/routeinfo.go
+++ b/routeinfo/routeinfo.go
@@ -75,9 +75,15 @@ func (rs *RouteInfoServer) Init() {
 }
 
 func (rs *RouteInfoServer) Stop() {
+	var wg sync.WaitGroup
 	for _, router := range rs.Routers {
-		router.GobgpServer.Stop()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			router.GobgpServer.Stop()
+		}()
 	}
+	wg.Wait()
 }
 
 type Router struct {

--- a/routeinfo/routeinfo_test.go
+++ b/routeinfo/routeinfo_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"log"
 	"math/rand"
+	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -48,6 +49,9 @@ func init() {
 }
 
 func BenchmarkLookupIPv4Random(b *testing.B) {
+	// no logs to slow us down
+	log.SetOutput(ioutil.Discard)
+	os.Stdout, _ = os.Open(os.DevNull)
 	addresses := make([]string, addressCacheSize)
 	for n := 0; n < addressCacheSize; n++ {
 		addresses[n] = strconv.Itoa(rand.Intn(255)) + "." + strconv.Itoa(rand.Intn(255)) + "." + strconv.Itoa(rand.Intn(255)) + "." + strconv.Itoa(rand.Intn(255))
@@ -61,6 +65,9 @@ func BenchmarkLookupIPv4Random(b *testing.B) {
 }
 
 func BenchmarkLookupIPv4Static(b *testing.B) {
+	// no logs to slow us down
+	log.SetOutput(ioutil.Discard)
+	os.Stdout, _ = os.Open(os.DevNull)
 	addresses := make([]string, addressCacheSize)
 	for n := 0; n < addressCacheSize; n++ {
 		addresses[n] = "1.1.1.1"
@@ -74,14 +81,18 @@ func BenchmarkLookupIPv4Static(b *testing.B) {
 }
 
 func BenchmarkEstablished(b *testing.B) {
-	b.ResetTimer()
+	// no logs to slow us down
+	log.SetOutput(ioutil.Discard)
+	os.Stdout, _ = os.Open(os.DevNull)
 	for n := 0; n < b.N; n++ {
 		router.Established()
 	}
 }
 
 func BenchmarkStatus(b *testing.B) {
-	b.ResetTimer()
+	// no logs to slow us down
+	log.SetOutput(ioutil.Discard)
+	os.Stdout, _ = os.Open(os.DevNull)
 	for n := 0; n < b.N; n++ {
 		router.Status()
 	}

--- a/routeinfo/routeinfo_test.go
+++ b/routeinfo/routeinfo_test.go
@@ -3,6 +3,8 @@ package routeinfo
 import (
 	"io/ioutil"
 	"log"
+	"math/rand"
+	"strconv"
 	"testing"
 
 	"gopkg.in/yaml.v2"

--- a/routeinfo/routeinfo_test.go
+++ b/routeinfo/routeinfo_test.go
@@ -6,24 +6,83 @@ import (
 	"math/rand"
 	"strconv"
 	"testing"
+	"time"
 
 	"gopkg.in/yaml.v2"
 )
 
-func BenchmarkLookup(b *testing.B) {
+var rs RouteInfoServer
+var router *Router
+
+const addressCacheSize = 10000
+
+func init() {
 	config, err := ioutil.ReadFile("config.yml")
 	if err != nil {
 		log.Printf("[error] reading config file: %s", err)
 		return
 	}
-
-	var rs RouteInfoServer
 	err = yaml.Unmarshal(config, &rs)
 	if err != nil {
 		log.Fatalf("[error] Error parsing configuration YAML: %v", err)
 	}
+	rs.Init()
+	for _, value := range rs.Routers {
+		// simply use whatever the first router is
+		router = value
+		break
+	}
 
+	// wait for sessions to be established and in sync
+	time.Sleep(10 * time.Second)
+	for {
+		_, ready := router.Status()
+		if ready == true {
+			break
+		} else {
+			time.Sleep(3 * time.Second)
+		}
+	}
+	// for good measure
+	time.Sleep(10 * time.Second)
+}
+
+func BenchmarkLookupIPv4Random(b *testing.B) {
+	addresses := make([]string, addressCacheSize)
+	for n := 0; n < addressCacheSize; n++ {
+		addresses[n] = strconv.Itoa(rand.Intn(255)) + "." + strconv.Itoa(rand.Intn(255)) + "." + strconv.Itoa(rand.Intn(255)) + "." + strconv.Itoa(rand.Intn(255))
+	}
+
+	// let's goooo
+	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		rs.Routers["router-1"].Lookup("1.1.1.1")
+		router.Lookup(addresses[n%addressCacheSize])
+	}
+}
+
+func BenchmarkLookupIPv4Static(b *testing.B) {
+	addresses := make([]string, addressCacheSize)
+	for n := 0; n < addressCacheSize; n++ {
+		addresses[n] = "1.1.1.1"
+	}
+
+	// let's goooo
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		router.Lookup(addresses[n%addressCacheSize])
+	}
+}
+
+func BenchmarkEstablished(b *testing.B) {
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		router.Established()
+	}
+}
+
+func BenchmarkStatus(b *testing.B) {
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		router.Status()
 	}
 }


### PR DESCRIPTION
The JSON/HTTP frontend now has these endpoints:
- `/status`: returns a list of configured peers and a boolean that indicates if they are connected
- `/prefix`: takes `prefix` and `router` as input and returns a matching prefix with all known paths

A basic web-frontend has been added, that consists of a bit of HTML, some CSS and a bit of JS that queries the API server and builds a website DOM from the response. The HTML can be integrated into existing websites, the config should obviously be set individually, but also the CSS should in most cases been seen as a template.